### PR TITLE
Require markupsafe < 2.1 and add jinja2<3.0 dev-requirement

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,3 +2,5 @@ sphinx >= 1.7.5
 sphinx_rtd_theme >= 0.4.0
 recommonmark >=0.5.0
 sphinx-autoapi >=1.1.0
+jinja2 < 3.0  # Dagster 0.12.8 requires Jinja2<3.0
+markupsafe < 2.1  # Jinja2<3.0 tries to import soft_unicode, which has been removed in markupsafe 2.1

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ install_requires = [
     "jupyter_client<7.0",
     "spinedb_api>=0.18.0",
     "pyzmq >=21.0",
+    "markupsafe < 2.1",  # dagster 0.12.8 requires Jinja2<3.0, which tries to import soft_unicode, which has been removed in markupsafe 2.1
 ]
 
 setup(

--- a/spine_engine/server/engine_server.py
+++ b/spine_engine/server/engine_server.py
@@ -136,11 +136,15 @@ class EngineServer(threading.Thread):
                         project_dir = project_dirs.get(request.request_id(), None)  # Get project dir based on job_id
                         if not project_dir:
                             print(f"Project for job_id:{request.request_id()} not found")
-                            msg = f"Starting DAG execution failed. Project directory for " \
-                                  f"job_id:{request.request_id()} not found."
+                            msg = (
+                                f"Starting DAG execution failed. Project directory for "
+                                f"job_id:{request.request_id()} not found."
+                            )
                             self.send_init_failed_reply(frontend, request.connection_id(), msg)
                             continue
-                        worker = RemoteExecutionService(self._context, request, job_id, project_dir, persistent_exec_mngr_q)
+                        worker = RemoteExecutionService(
+                            self._context, request, job_id, project_dir, persistent_exec_mngr_q
+                        )
                     elif request.cmd() == "stop_execution":
                         worker = workers.get(request.request_id(), None)  # Get DAG execution worker based on job Id
                         if not worker:
@@ -155,8 +159,10 @@ class EngineServer(threading.Thread):
                         project_dir = project_dirs.get(request.request_id(), None)  # Get project dir based on job_id
                         if not project_dir:
                             print(f"Project for job_id:{request.request_id()} not found")
-                            msg = f"Retrieving project for job_id {request.request_id()} failed. " \
-                                  f"Project directory not found."
+                            msg = (
+                                f"Retrieving project for job_id {request.request_id()} failed. "
+                                f"Project directory not found."
+                            )
                             self.send_init_failed_reply(frontend, request.connection_id(), msg)
                             continue
                         worker = ProjectRetrieverService(self._context, request, job_id, project_dir)
@@ -165,8 +171,10 @@ class EngineServer(threading.Thread):
                         exec_mngr = self.persistent_exec_mngrs.get(exec_mngr_key, None)
                         if not exec_mngr:
                             print(f"Persistent exec. mngr for key:{exec_mngr_key} not found.")
-                            msg = f"Executing command:{request.data()[1]} - {request.data()[2]} in persistent " \
-                                  f"manager failed. Persistent execution manager for key {exec_mngr_key} not found."
+                            msg = (
+                                f"Executing command:{request.data()[1]} - {request.data()[2]} in persistent "
+                                f"manager failed. Persistent execution manager for key {exec_mngr_key} not found."
+                            )
                             self.send_init_failed_reply(frontend, request.connection_id(), msg)
                             continue
                         worker = PersistentExecutionService(self._context, request, job_id, exec_mngr)
@@ -236,22 +244,25 @@ class EngineServer(threading.Thread):
         b_json_str_server_msg = msg[1]  # binary string
         if len(b_json_str_server_msg) <= 10:  # Message size too small
             print(f"User data frame too small [{len(msg[1])}]. msg:{msg}")
-            self.send_init_failed_reply(socket, msg[0], f"User data frame too small "
-                                                        f"- Malformed message sent to server.")
+            self.send_init_failed_reply(
+                socket, msg[0], f"User data frame too small " f"- Malformed message sent to server."
+            )
             return None
         try:
             json_str_server_msg = b_json_str_server_msg.decode("utf-8")  # json string
         except UnicodeDecodeError as e:
             print(f"Decoding received msg '{msg[1]} ' failed. \nUnicodeDecodeError: {e}")
-            self.send_init_failed_reply(socket, msg[0], f"UnicodeDecodeError: {e}. "
-                                                        f"- Malformed message sent to server.")
+            self.send_init_failed_reply(
+                socket, msg[0], f"UnicodeDecodeError: {e}. " f"- Malformed message sent to server."
+            )
             return None
         # Load JSON string into dictionary
         try:
             server_msg = json.loads(json_str_server_msg)  # dictionary
         except json.decoder.JSONDecodeError as e:
-            self.send_init_failed_reply(socket, msg[0], f"json.decoder.JSONDecodeError: {e}. "
-                                                        f"- Message parsing error at server.")
+            self.send_init_failed_reply(
+                socket, msg[0], f"json.decoder.JSONDecodeError: {e}. " f"- Message parsing error at server."
+            )
             return None
         # server_msg is now a dict with keys: 'command', 'id', 'data', and 'files'
         data_str = server_msg["data"]  # String

--- a/spine_engine/server/persistent_execution_service.py
+++ b/spine_engine/server/persistent_execution_service.py
@@ -23,6 +23,7 @@ from spine_engine.server.service_base import ServiceBase
 
 class PersistentExecutionService(threading.Thread, ServiceBase):
     """Class for interacting with a persistent execution manager running on server."""
+
     def __init__(self, context, request, job_id, persistent_exec_mngr):
         """
         Args:

--- a/spine_engine/server/ping_service.py
+++ b/spine_engine/server/ping_service.py
@@ -24,6 +24,7 @@ from spine_engine.server.util.server_message import ServerMessage
 
 class PingService(threading.Thread, ServiceBase):
     """Class for handling ping requests."""
+
     def __init__(self, context, request, job_id):
         """Initializes instance.
 

--- a/spine_engine/server/project_extractor_service.py
+++ b/spine_engine/server/project_extractor_service.py
@@ -61,7 +61,9 @@ class ProjectExtractorService(threading.Thread, ServiceBase):
             self.send_completed_with_error("Project ZIP file missing")
             return
         # Make a new local project directory based on project name in request
-        local_project_dir = os.path.join(ProjectExtractorService.INTERNAL_PROJECT_DIR, dir_name + "__" + uuid.uuid4().hex)
+        local_project_dir = os.path.join(
+            ProjectExtractorService.INTERNAL_PROJECT_DIR, dir_name + "__" + uuid.uuid4().hex
+        )
         # Create project directory
         try:
             os.makedirs(local_project_dir)
@@ -82,8 +84,10 @@ class ProjectExtractorService(threading.Thread, ServiceBase):
             return
         # Check that the size of received bytes and the saved ZIP file match
         if not len(self.request.zip_file()) == os.path.getsize(zip_path):
-            print(f"Error: Size mismatch in saving ZIP file. Received bytes:{len(self.request.zip_file())}. "
-                  f"ZIP file size:{os.path.getsize(zip_path)}")
+            print(
+                f"Error: Size mismatch in saving ZIP file. Received bytes:{len(self.request.zip_file())}. "
+                f"ZIP file size:{os.path.getsize(zip_path)}"
+            )
         # Extract the saved file
         print(f"Extracting {file_names[0]} [{get_file_size(os.path.getsize(zip_path))}] to: {local_project_dir}")
         try:

--- a/spine_engine/server/project_retriever_service.py
+++ b/spine_engine/server/project_retriever_service.py
@@ -27,6 +27,7 @@ from spine_engine.server.util.server_message import ServerMessage
 
 class ProjectRetrieverService(threading.Thread, ServiceBase):
     """Class for transmitting a project back to client."""
+
     def __init__(self, context, request, job_id, project_dir):
         """Initializes instance.
 

--- a/spine_engine/server/remote_execution_service.py
+++ b/spine_engine/server/remote_execution_service.py
@@ -28,6 +28,7 @@ from spine_engine.server.util.zip_handler import ZipHandler
 class RemoteExecutionService(threading.Thread, ServiceBase):
     """Executes a DAG contained in the client request. Project must
     be on server before running this service."""
+
     def __init__(self, context, request, job_id, project_dir, persistent_exec_mngr_q):
         """
         Args:
@@ -92,7 +93,8 @@ class RemoteExecutionService(threading.Thread, ServiceBase):
         # Send reply to 'start_execution' request to client with the push socket port for
         # pulling events and worker job id for stopping execution
         self.request.send_response(
-            self.worker_socket, ("remote_execution_started", str(push_port), self.job_id), (self.job_id, "in_progress"))
+            self.worker_socket, ("remote_execution_started", str(push_port), self.job_id), (self.job_id, "in_progress")
+        )
         converted_data = self.convert_input(engine_data, self.local_project_dir)
         try:
             self.engine = SpineEngine(**converted_data)

--- a/spine_engine/server/request.py
+++ b/spine_engine/server/request.py
@@ -21,6 +21,7 @@ from spine_engine.server.util.server_message import ServerMessage
 
 class Request:
     """Class for bundling the received request and associated data together."""
+
     def __init__(self, msg, cmd, request_id, data, filenames):
         """Init class.
 

--- a/spine_engine/server/service_base.py
+++ b/spine_engine/server/service_base.py
@@ -20,6 +20,7 @@ import zmq
 
 class ServiceBase:
     """Service base class."""
+
     def __init__(self, context, request, job_id):
         """Initializes instance.
 

--- a/spine_engine/server/start_server.py
+++ b/spine_engine/server/start_server.py
@@ -24,9 +24,11 @@ from spine_engine.server.engine_server import EngineServer, ServerSecurityModel
 def main(argv):
     """Spine Engine server main."""
     if len(argv) != 2 and len(argv) != 4:
-        print(f"Spine Engine Server\n\nUsage:\n  python {argv[0]} <port>\n"
-              f"or\n  python {argv[0]} <port> stonehouse <path_to_security_folder>\n"
-              f"to enable security.")
+        print(
+            f"Spine Engine Server\n\nUsage:\n  python {argv[0]} <port>\n"
+            f"or\n  python {argv[0]} <port> stonehouse <path_to_security_folder>\n"
+            f"to enable security."
+        )
         return
     server = None
     try:

--- a/spine_engine/server/util/server_message.py
+++ b/spine_engine/server/util/server_message.py
@@ -20,6 +20,7 @@ import json
 
 class ServerMessage:
     """Class for communicating requests and replies between the client and the server."""
+
     def __init__(self, command, req_id, data, files=None):
         """
         Supported requests and expected server responses

--- a/spine_engine/server/util/zip_handler.py
+++ b/spine_engine/server/util/zip_handler.py
@@ -23,6 +23,7 @@ from spine_engine.utils.helpers import get_file_size
 
 class ZipHandler:
     """ZIP file handler."""
+
     @staticmethod
     def package(src_folder, dst_folder, fname):
         """Packages a directory into a ZIP-file.

--- a/spine_engine/utils/helpers.py
+++ b/spine_engine/utils/helpers.py
@@ -324,16 +324,16 @@ def get_file_size(size_in_bytes):
         str: Human readable file size
     """
     kb = 1024
-    mb = 1024*1024
-    gb = 1024*1024*1024
+    mb = 1024 * 1024
+    gb = 1024 * 1024 * 1024
     if size_in_bytes <= kb:
         return str(size_in_bytes) + " B"
     if kb < size_in_bytes <= mb:
-        return str(round(size_in_bytes/kb, 1)) + " KB"
+        return str(round(size_in_bytes / kb, 1)) + " KB"
     elif mb < size_in_bytes < gb:
-        return str(round(size_in_bytes/mb, 1)) + " MB"
+        return str(round(size_in_bytes / mb, 1)) + " MB"
     else:
-        return str(round(size_in_bytes/gb, 1)) + " GB"
+        return str(round(size_in_bytes / gb, 1)) + " GB"
 
 
 class PartCount:


### PR DESCRIPTION
We require dagster 0.12.8, which requires jinja2<3.0. However, jinja2<3.0 tries to import soft_unicode from the latest markupsafe, which results into a traceback when trying to build our documentation. soft_unicode was removed from markupsafe 2.1, so we require a compatible version.

## Checklist before merging
- [ ] Documentation (also in Toolbox repo) is up-to-date
- [ ] Release notes in Toolbox repo have been updated
- [ ] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
