### PR TITLE
Fix occasional Traceback in the Engine

### DIFF
--- a/spine_engine/execution_managers/persistent_execution_manager.py
+++ b/spine_engine/execution_managers/persistent_execution_manager.py
@@ -225,7 +225,10 @@ class PersistentManagerBase:
         if catch_exception:
             cmd = self._catch_exception_command(cmd) if cmd else ""
         cmd += os.linesep
-        self._persistent.stdin.write(cmd.encode("UTF8"))
+        try:
+            self._persistent.stdin.write(cmd.encode("UTF8"))
+        except ValueError:
+            return False
         try:
             self._persistent.stdin.flush()
             return True
@@ -722,7 +725,6 @@ class PersistentExecutionManagerBase(ExecutionManagerBase):
             commands (list): List of commands to execute in the persistent process
             alias (str): an alias name for the manager
             group_id (str, optional): item group that will execute using this kernel
-            server_ip (str): Engine Server IP address
         """
         super().__init__(logger)
         self._args = args

--- a/tests/execution_managers/__init__.py
+++ b/tests/execution_managers/__init__.py
@@ -1,0 +1,11 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Engine.
+# Spine Engine is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for ``execution_managers`` package."""

--- a/tests/execution_managers/test_persistent_execution_manager.py
+++ b/tests/execution_managers/test_persistent_execution_manager.py
@@ -1,0 +1,69 @@
+######################################################################################################################
+# Copyright (C) 2017-2022 Spine project consortium
+# This file is part of Spine Engine.
+# Spine Engine is free software: you can redistribute it and/or modify it under the terms of the GNU Lesser General
+# Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option)
+# any later version. This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+# Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
+# this program. If not, see <http://www.gnu.org/licenses/>.
+######################################################################################################################
+"""Unit tests for ``persistent_execution_manager`` module."""
+import unittest
+from unittest.mock import MagicMock
+from spine_engine.execution_managers.persistent_execution_manager import (
+    PythonPersistentExecutionManager,
+    issue_persistent_command,
+)
+from spine_engine.utils.execution_resources import persistent_process_semaphore
+
+
+class TestPythonPersistentExecutionManager(unittest.TestCase):
+    def test_reuse_process(self):
+        logger = MagicMock()
+        exec_mngr1 = PythonPersistentExecutionManager(
+            logger, ["python"], ['print("hello")'], "alias", group_id="SomeGroup"
+        )
+        exec_mngr1.run_until_complete()
+        exec_mngr2 = PythonPersistentExecutionManager(
+            logger, ["python"], ['print("hello again")'], "another alias", group_id="SomeGroup"
+        )
+        self.assertEqual(exec_mngr1._persistent_manager, exec_mngr2._persistent_manager)
+        logger.msg_warning.emit.assert_called_once()
+        exec_mngr1._persistent_manager.kill_process()
+
+    def test_do_not_reuse_unfinished_process(self):
+        persistent_process_semaphore.set_limit(2)
+        logger = MagicMock()
+        exec_mngr1 = PythonPersistentExecutionManager(
+            logger, ["python"], ['print("hello")'], "alias", group_id="SomeGroup"
+        )
+        exec_mngr2 = PythonPersistentExecutionManager(
+            logger, ["python"], ['print("hello again")'], "another alias", group_id="SomeGroup"
+        )
+        self.assertNotEqual(exec_mngr1._persistent_manager, exec_mngr2._persistent_manager)
+        exec_mngr1._persistent_manager.kill_process()
+        exec_mngr2._persistent_manager.kill_process()
+
+    def test_failing_process(self):
+        logger = MagicMock()
+        exec_mngr = PythonPersistentExecutionManager(
+            logger, ["python"], ["exit(666)"], "my execution", group_id="SomeGroup"
+        )
+        self.assertEqual(exec_mngr.run_until_complete(), -1)
+        self.assertTrue(exec_mngr.killed)
+        expected_messages = [
+            {"type": "persistent_started", "language": "python"},
+            {"type": "execution_started", "args": "python"},
+            {"type": "stdin", "data": "# Running my execution"},
+            {"type": "stdout", "data": "Kernel died (×_×)"},
+        ]
+        message_emits = logger.msg_persistent_execution.emit.call_args_list
+        self.assertEqual(len(message_emits), len(expected_messages))
+        for call, expected_message in zip(message_emits, expected_messages):
+            for key, expected in expected_message.items():
+                self.assertEqual(call[0][0][key], expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/execution_managers/test_process_execution_manager.py
+++ b/tests/execution_managers/test_process_execution_manager.py
@@ -8,20 +8,11 @@
 # Public License for more details. You should have received a copy of the GNU Lesser General Public License along with
 # this program. If not, see <http://www.gnu.org/licenses/>.
 ######################################################################################################################
-
-"""
-Unit tests for execution_managers module.
-
-:author: M. Marin (KTH)
-:date:   12.10.2020
-"""
-
+"""Unit tests for ``process_execution_manager`` module."""
 import unittest
 from unittest.mock import MagicMock
 from tempfile import TemporaryDirectory
 from spine_engine.execution_managers.process_execution_manager import ProcessExecutionManager
-from spine_engine.execution_managers.persistent_execution_manager import PythonPersistentExecutionManager
-from spine_engine.utils.execution_resources import persistent_process_semaphore
 
 
 class TestStandardExecutionManager(unittest.TestCase):
@@ -73,36 +64,6 @@ class TestStandardExecutionManager(unittest.TestCase):
         logger.msg_proc.emit.assert_called_once()
         logger.msg_proc.emit.assert_called_with(f"{workdir}")
         self.assertEqual(ret, 0)
-
-
-class TestPersistentExecutionManager(unittest.TestCase):
-    def test_reuse_process(self):
-        logger = MagicMock()
-        logger.msg_warning = MagicMock()
-        exec_mngr1 = PythonPersistentExecutionManager(
-            logger, ["python"], ['print("hello")'], "alias", group_id="SomeGroup"
-        )
-        exec_mngr1.run_until_complete()
-        exec_mngr2 = PythonPersistentExecutionManager(
-            logger, ["python"], ['print("hello again")'], "another alias", group_id="SomeGroup"
-        )
-        self.assertEqual(exec_mngr1._persistent_manager, exec_mngr2._persistent_manager)
-        logger.msg_warning.emit.assert_called_once()
-        exec_mngr1._persistent_manager.kill_process()
-
-    def test_do_not_reuse_unfinished_process(self):
-        persistent_process_semaphore.set_limit(2)
-        logger = MagicMock()
-        logger.msg_warning = MagicMock()
-        exec_mngr1 = PythonPersistentExecutionManager(
-            logger, ["python"], ['print("hello")'], "alias", group_id="SomeGroup"
-        )
-        exec_mngr2 = PythonPersistentExecutionManager(
-            logger, ["python"], ['print("hello again")'], "another alias", group_id="SomeGroup"
-        )
-        self.assertNotEqual(exec_mngr1._persistent_manager, exec_mngr2._persistent_manager)
-        exec_mngr1._persistent_manager.kill_process()
-        exec_mngr2._persistent_manager.kill_process()
 
 
 if __name__ == '__main__':

--- a/tests/server/test_PingService.py
+++ b/tests/server/test_PingService.py
@@ -22,7 +22,6 @@ from spine_engine.server.engine_server import EngineServer, ServerSecurityModel
 
 
 class TestPingService(unittest.TestCase):
-
     def setUp(self):
         self.context = zmq.Context()
         self.socket = self.context.socket(zmq.DEALER)

--- a/tests/server/test_ProjectExtractorService.py
+++ b/tests/server/test_ProjectExtractorService.py
@@ -27,7 +27,6 @@ from spine_engine.server.engine_server import EngineServer, ServerSecurityModel
 
 
 class TestProjectExtractorService(unittest.TestCase):
-
     def setUp(self):
         self._temp_dir = TemporaryDirectory()
         self.service = EngineServer("tcp", 5559, ServerSecurityModel.NONE, "")
@@ -43,7 +42,10 @@ class TestProjectExtractorService(unittest.TestCase):
         if not self.context.closed:
             self.context.term()
 
-    @mock.patch("spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR", new_callable=mock.PropertyMock)
+    @mock.patch(
+        "spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR",
+        new_callable=mock.PropertyMock,
+    )
     def test_project_extraction(self, mock_proj_dir):
         mock_proj_dir.return_value = self._temp_dir.name
         with open(os.path.join(str(Path(__file__).parent), "helloworld.zip"), "rb") as f:
@@ -92,4 +94,3 @@ class TestProjectExtractorService(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/tests/server/test_RemoteExecutionService.py
+++ b/tests/server/test_RemoteExecutionService.py
@@ -55,7 +55,10 @@ class TestRemoteExecutionService(unittest.TestCase):
         except RecursionError:
             print("RecursionError due to a PermissionError on Windows. Server resources not cleaned up properly.")
 
-    @mock.patch("spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR", new_callable=mock.PropertyMock)
+    @mock.patch(
+        "spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR",
+        new_callable=mock.PropertyMock,
+    )
     def test_remote_execution1(self, mock_proj_dir):
         """Tests executing a Hello World (DC -> Python Tool) project."""
         mock_proj_dir.return_value = self._temp_dir.name
@@ -80,7 +83,10 @@ class TestRemoteExecutionService(unittest.TestCase):
         self.assertEqual("remote_execution_started", start_response_msg_data[0])
         self.receive_events(start_response_msg_data[1])
 
-    @mock.patch("spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR", new_callable=mock.PropertyMock)
+    @mock.patch(
+        "spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR",
+        new_callable=mock.PropertyMock,
+    )
     def test_remote_execution2(self, mock_project_dir):
         """Tests executing a single DAG project with 3 items (DC -> Importer -> DS)."""
         mock_project_dir.return_value = self._temp_dir.name
@@ -105,7 +111,10 @@ class TestRemoteExecutionService(unittest.TestCase):
         self.assertEqual("remote_execution_started", start_response_msg_data[0])
         self.receive_events(start_response_msg_data[1])
 
-    @mock.patch("spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR", new_callable=mock.PropertyMock)
+    @mock.patch(
+        "spine_engine.server.project_extractor_service.ProjectExtractorService.INTERNAL_PROJECT_DIR",
+        new_callable=mock.PropertyMock,
+    )
     def test_loop_calls(self, mock_proj_dir):
         """Tests executing the Hellow World project (DC -> Tool) five times in a row."""
         mock_proj_dir.return_value = self._temp_dir.name
@@ -170,12 +179,7 @@ class TestRemoteExecutionService(unittest.TestCase):
 
     def make_default_item_dict(self, item_type):
         """Keep up-to-date with spinetoolbox.project_item.project_item.item_dict()."""
-        return {
-            "type": item_type,
-            "description": "",
-            "x": random.uniform(0, 100),
-            "y": random.uniform(0, 100),
-        }
+        return {"type": item_type, "description": "", "x": random.uniform(0, 100), "y": random.uniform(0, 100)}
 
     def make_dc_item_dict(self, file_ref=None):
         """Make a Data Connection item_dict.
@@ -209,18 +213,20 @@ class TestRemoteExecutionService(unittest.TestCase):
 
     def make_ds_item_dict(self):
         d = self.make_default_item_dict("Data Store")
-        d["url"] = {"dialect": "sqlite", "username": "", "password": "", "host": "", "port": "", "database": {"type": "path", "relative": True, "path": ".spinetoolbox/items/ds1/DS1.sqlite"}}
+        d["url"] = {
+            "dialect": "sqlite",
+            "username": "",
+            "password": "",
+            "host": "",
+            "port": "",
+            "database": {"type": "path", "relative": True, "path": ".spinetoolbox/items/ds1/DS1.sqlite"},
+        }
         return d
 
     @staticmethod
     def make_python_tool_spec_dict(
-            name,
-            includes,
-            input_files,
-            exec_in_work,
-            includes_main_path,
-            def_file_path,
-            exec_settings=None):
+        name, includes, input_files, exec_in_work, includes_main_path, def_file_path, exec_settings=None
+    ):
         return {
             "name": name,
             "tooltype": "python",
@@ -241,19 +247,31 @@ class TestRemoteExecutionService(unittest.TestCase):
         d = dict()
         d["name"] = "Importer 1 - units.xlsx"
         d["item_type"] = "Importer"
-        d["mapping"] = {"table_mappings":
-                            {"Sheet1":
-                                 [
-                                     {"": {"mapping": [{"map_type": "ObjectClass", "position": 0},
-                                                       {"map_type": "Object", "position": 1},
-                                                       {"map_type": "ObjectMetadata", "position": "hidden"}]}}
-                                 ]
-                            },
+        d["mapping"] = {
+            "table_mappings": {
+                "Sheet1": [
+                    {
+                        "": {
+                            "mapping": [
+                                {"map_type": "ObjectClass", "position": 0},
+                                {"map_type": "Object", "position": 1},
+                                {"map_type": "ObjectMetadata", "position": "hidden"},
+                            ]
+                        }
+                    }
+                ]
+            },
             "selected_tables": ["Sheet1"],
-            "table_options": {"Sheet1": {}}, "table_types": {"Sheet1": {"0": "string", "1": "string"}},
-            "table_default_column_type": {}, "table_row_types": {}, "source_type": "ExcelConnector"}
-        d["description"] = "",
-        d["definition_file_path"] = "C:\\data\\SpineToolboxData\\Projects\\Simple Importer\\Importer 1 - units.xlsx.json"
+            "table_options": {"Sheet1": {}},
+            "table_types": {"Sheet1": {"0": "string", "1": "string"}},
+            "table_default_column_type": {},
+            "table_row_types": {},
+            "source_type": "ExcelConnector",
+        }
+        d["description"] = ("",)
+        d[
+            "definition_file_path"
+        ] = "C:\\data\\SpineToolboxData\\Projects\\Simple Importer\\Importer 1 - units.xlsx.json"
         return d
 
     def make_engine_data_for_helloworld_project(self):
@@ -264,13 +282,15 @@ class TestRemoteExecutionService(unittest.TestCase):
         """
         tool_item_dict = self.make_tool_item_dict("Simple Tool Spec", False)
         dc_item_dict = self.make_dc_item_dict(file_ref=[{"type": "path", "relative": True, "path": "input_file.txt"}])
-        spec_dict = self.make_python_tool_spec_dict(name="Simple Tool Spec",
-                                                    includes=["simple_script.py"],
-                                                    input_files=["input_file.txt"],
-                                                    exec_in_work=True,
-                                                    includes_main_path="../../..",
-                                                    def_file_path="C:/data/temp/.spinetoolbox/specifications/Tool/simple_tool_spec.json",
-                                                    exec_settings={"env": "", "kernel_spec_name": "py38", "use_jupyter_console": False, "executable": ""})
+        spec_dict = self.make_python_tool_spec_dict(
+            name="Simple Tool Spec",
+            includes=["simple_script.py"],
+            input_files=["input_file.txt"],
+            exec_in_work=True,
+            includes_main_path="../../..",
+            def_file_path="C:/data/temp/.spinetoolbox/specifications/Tool/simple_tool_spec.json",
+            exec_settings={"env": "", "kernel_spec_name": "py38", "use_jupyter_console": False, "executable": ""},
+        )
         item_dicts = dict()
         item_dicts["Data Connection 1"] = dc_item_dict
         item_dicts["Simple Tool"] = tool_item_dict
@@ -279,7 +299,13 @@ class TestRemoteExecutionService(unittest.TestCase):
         engine_data = {
             "items": item_dicts,
             "specifications": specification_dicts,
-            "connections": [{"name": "from Data Connection 1 to Simple Tool", "from": ["Data Connection 1", "right"], "to": ["Simple Tool", "left"]}],
+            "connections": [
+                {
+                    "name": "from Data Connection 1 to Simple Tool",
+                    "from": ["Data Connection 1", "right"],
+                    "to": ["Simple Tool", "left"],
+                }
+            ],
             "jumps": [],
             "execution_permits": {"Data Connection 1": True, "Simple Tool": True},
             "items_module_name": "spine_items",
@@ -307,7 +333,15 @@ class TestRemoteExecutionService(unittest.TestCase):
         engine_data = {
             "items": item_dicts,
             "specifications": specification_dicts,
-            "connections":  [{"name": "from Raw data to Importer 1", "from": ["Raw data", "right"], "to": ["Importer 1", "left"]}, {"name": "from Importer 1 to DS1", "from": ["Importer 1", "right"], "to": ["DS1", "left"], "options": {"purge_before_writing": True, "purge_settings": None}}],
+            "connections": [
+                {"name": "from Raw data to Importer 1", "from": ["Raw data", "right"], "to": ["Importer 1", "left"]},
+                {
+                    "name": "from Importer 1 to DS1",
+                    "from": ["Importer 1", "right"],
+                    "to": ["DS1", "left"],
+                    "options": {"purge_before_writing": True, "purge_settings": None},
+                },
+            ],
             "jumps": [],
             "execution_permits": {"Importer 1": True, "DS1": True, "Raw data": True},
             "items_module_name": "spine_items",

--- a/tests/server/test_start_server.py
+++ b/tests/server/test_start_server.py
@@ -21,7 +21,6 @@ from spine_engine.server.start_server import main
 
 
 class TestStartServer(unittest.TestCase):
-
     def test_start_server(self):
         server = Process(target=main, args=(["", "5001"],))
         server.start()

--- a/tests/server/util/test_EventDataConverter.py
+++ b/tests/server/util/test_EventDataConverter.py
@@ -22,24 +22,96 @@ from spine_engine.server.util.event_data_converter import EventDataConverter
 
 
 class TestEventDataConverter(unittest.TestCase):
-
     def make_event_data(self):
-        test_events = [('exec_started', {'item_name': 'helloworld', 'direction': 'BACKWARD'}),
-                       ('exec_started', {'item_name': 'Data Connection 1', 'direction': 'BACKWARD'}),
-                       ('exec_finished', {'item_name': 'helloworld', 'direction': 'BACKWARD', 'state': 'RUNNING', 'item_state': ItemExecutionFinishState.SUCCESS}),
-                       ('exec_finished', {'item_name': 'Data Connection 1', 'direction': 'BACKWARD', 'state': 'RUNNING', 'item_state': ItemExecutionFinishState.SUCCESS}),
-                       ('exec_started', {'item_name': 'Data Connection 1', 'direction': 'FORWARD'}),
-                       ('event_msg', {'item_name': 'Data Connection 1', 'filter_id': '', 'msg_type': 'msg_success', 'msg_text': 'Executing Data Connection Data Connection 1 finished'}),
-                       ('exec_finished', {'item_name': 'Data Connection 1', 'direction': 'FORWARD', 'state': 'RUNNING', 'item_state': ItemExecutionFinishState.SUCCESS}),
-                       ('flash', {'item_name': 'from Data Connection 1 to helloworld'}),
-                       ('exec_started', {'item_name': 'helloworld', 'direction': 'FORWARD'}),
-                       ('event_msg', {'item_name': 'helloworld', 'filter_id': '', 'msg_type': 'msg', 'msg_text': "*** Executing Tool specification <b>helloworld2</b> in <a style='color:#99CCFF;' title='C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1'href='file:///C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1'>source directory</a> ***"}),
-                       ('persistent_execution_msg', {'item_name': 'helloworld', 'filter_id': '', 'type': 'persistent_started', 'key': '6ceeb59271114fc2a0f787266f72dedc', 'language': 'python'}),
-                       ('persistent_execution_msg', {'item_name': 'helloworld', 'filter_id': '', 'type': 'stdin', 'data': '# Running python helloworld.py'}),
-                       ('persistent_execution_msg', {'item_name': 'helloworld', 'filter_id': '', 'type': 'stdout', 'data': 'helloo'}),
-                       ('event_msg', {'item_name': 'helloworld', 'filter_id': '', 'msg_type': 'msg', 'msg_text': "*** Archiving output files to <a style='color:#BB99FF;' title='C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1\\.spinetoolbox\\items\\helloworld\\output\\2022-08-19T13.03.13' href='file:///C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1\\.spinetoolbox\\items\\helloworld\\output\\2022-08-19T13.03.13'>results directory</a> ***"}),
-                       ('exec_finished', {'item_name': 'helloworld', 'direction': 'FORWARD', 'state': 'RUNNING', 'item_state': ItemExecutionFinishState.SUCCESS}),
-                       ('dag_exec_finished', 'COMPLETED')]
+        test_events = [
+            ('exec_started', {'item_name': 'helloworld', 'direction': 'BACKWARD'}),
+            ('exec_started', {'item_name': 'Data Connection 1', 'direction': 'BACKWARD'}),
+            (
+                'exec_finished',
+                {
+                    'item_name': 'helloworld',
+                    'direction': 'BACKWARD',
+                    'state': 'RUNNING',
+                    'item_state': ItemExecutionFinishState.SUCCESS,
+                },
+            ),
+            (
+                'exec_finished',
+                {
+                    'item_name': 'Data Connection 1',
+                    'direction': 'BACKWARD',
+                    'state': 'RUNNING',
+                    'item_state': ItemExecutionFinishState.SUCCESS,
+                },
+            ),
+            ('exec_started', {'item_name': 'Data Connection 1', 'direction': 'FORWARD'}),
+            (
+                'event_msg',
+                {
+                    'item_name': 'Data Connection 1',
+                    'filter_id': '',
+                    'msg_type': 'msg_success',
+                    'msg_text': 'Executing Data Connection Data Connection 1 finished',
+                },
+            ),
+            (
+                'exec_finished',
+                {
+                    'item_name': 'Data Connection 1',
+                    'direction': 'FORWARD',
+                    'state': 'RUNNING',
+                    'item_state': ItemExecutionFinishState.SUCCESS,
+                },
+            ),
+            ('flash', {'item_name': 'from Data Connection 1 to helloworld'}),
+            ('exec_started', {'item_name': 'helloworld', 'direction': 'FORWARD'}),
+            (
+                'event_msg',
+                {
+                    'item_name': 'helloworld',
+                    'filter_id': '',
+                    'msg_type': 'msg',
+                    'msg_text': "*** Executing Tool specification <b>helloworld2</b> in <a style='color:#99CCFF;' title='C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1'href='file:///C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1'>source directory</a> ***",
+                },
+            ),
+            (
+                'persistent_execution_msg',
+                {
+                    'item_name': 'helloworld',
+                    'filter_id': '',
+                    'type': 'persistent_started',
+                    'key': '6ceeb59271114fc2a0f787266f72dedc',
+                    'language': 'python',
+                },
+            ),
+            (
+                'persistent_execution_msg',
+                {'item_name': 'helloworld', 'filter_id': '', 'type': 'stdin', 'data': '# Running python helloworld.py'},
+            ),
+            (
+                'persistent_execution_msg',
+                {'item_name': 'helloworld', 'filter_id': '', 'type': 'stdout', 'data': 'helloo'},
+            ),
+            (
+                'event_msg',
+                {
+                    'item_name': 'helloworld',
+                    'filter_id': '',
+                    'msg_type': 'msg',
+                    'msg_text': "*** Archiving output files to <a style='color:#BB99FF;' title='C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1\\.spinetoolbox\\items\\helloworld\\output\\2022-08-19T13.03.13' href='file:///C:\\data\\GIT\\SPINEENGINE\\spine_engine\\server\\received_projects\\helloworld__35bc62cea0324e8788144ce81342f4f1\\.spinetoolbox\\items\\helloworld\\output\\2022-08-19T13.03.13'>results directory</a> ***",
+                },
+            ),
+            (
+                'exec_finished',
+                {
+                    'item_name': 'helloworld',
+                    'direction': 'FORWARD',
+                    'state': 'RUNNING',
+                    'item_state': ItemExecutionFinishState.SUCCESS,
+                },
+            ),
+            ('dag_exec_finished', 'COMPLETED'),
+        ]
         return test_events
 
     def test_convert(self):

--- a/tests/server/util/test_ServerMessage.py
+++ b/tests/server/util/test_ServerMessage.py
@@ -21,55 +21,153 @@ from spine_engine.server.util.server_message import ServerMessage
 
 
 class TestServerMessage(unittest.TestCase):
-
     def make_engine_data1(self):
-        engine_data = {'items': {
-            'T1': {'type': 'Tool', 'description': '', 'x': -81.09856329675559, 'y': -7.8289158512399695,
-                   'specification': 'a', 'execute_in_work': True, 'cmd_line_args': []},
-            'DC1': {'type': 'Data Connection', 'description': '', 'x': -249.4143275244174, 'y': -122.2554094109619,
-                    'file_references': [], 'db_references': [], 'db_credentials': {}}}, 'specifications': {'Tool': [
-            {'name': 'a', 'tooltype': 'python', 'includes': ['a.py'], 'description': '', 'inputfiles': ['a.txt'],
-             'inputfiles_opt': [], 'outputfiles': [], 'cmdline_args': [], 'execute_in_work': False,
-             'includes_main_path': '.',
-             'execution_settings': {'env': '', 'kernel_spec_name': 'python38', 'use_jupyter_console': False,
-                                    'executable': ''},
-             'definition_file_path': 'C:\\Users\\ttepsa\\OneDrive - Teknologian Tutkimuskeskus VTT\\Documents\\SpineToolboxProjects\\remote test 2 dags\\.spinetoolbox\\specifications\\Tool\\a.json'}]},
-                      'connections': [{'name': 'from DC1 to T1', 'from': ['DC1', 'right'], 'to': ['T1', 'left']}],
-                      'jumps': [], 'execution_permits': {'T1': True, 'DC1': True}, 'items_module_name': 'spine_items',
-                      'settings': {'engineSettings/remoteExecutionEnabled': 'true',
-                                   'engineSettings/remoteHost': '192.168.56.69', 'engineSettings/remotePort': 50001,
-                                   'engineSettings/remoteSecurityFolder': '', 'engineSettings/remoteSecurityModel': ''},
-                      'project_dir': 'C:/Users/ttepsa/OneDrive - Teknologian Tutkimuskeskus VTT/Documents/SpineToolboxProjects/remote test 2 dags'}
+        engine_data = {
+            'items': {
+                'T1': {
+                    'type': 'Tool',
+                    'description': '',
+                    'x': -81.09856329675559,
+                    'y': -7.8289158512399695,
+                    'specification': 'a',
+                    'execute_in_work': True,
+                    'cmd_line_args': [],
+                },
+                'DC1': {
+                    'type': 'Data Connection',
+                    'description': '',
+                    'x': -249.4143275244174,
+                    'y': -122.2554094109619,
+                    'file_references': [],
+                    'db_references': [],
+                    'db_credentials': {},
+                },
+            },
+            'specifications': {
+                'Tool': [
+                    {
+                        'name': 'a',
+                        'tooltype': 'python',
+                        'includes': ['a.py'],
+                        'description': '',
+                        'inputfiles': ['a.txt'],
+                        'inputfiles_opt': [],
+                        'outputfiles': [],
+                        'cmdline_args': [],
+                        'execute_in_work': False,
+                        'includes_main_path': '.',
+                        'execution_settings': {
+                            'env': '',
+                            'kernel_spec_name': 'python38',
+                            'use_jupyter_console': False,
+                            'executable': '',
+                        },
+                        'definition_file_path': 'C:\\Users\\ttepsa\\OneDrive - Teknologian Tutkimuskeskus VTT\\Documents\\SpineToolboxProjects\\remote test 2 dags\\.spinetoolbox\\specifications\\Tool\\a.json',
+                    }
+                ]
+            },
+            'connections': [{'name': 'from DC1 to T1', 'from': ['DC1', 'right'], 'to': ['T1', 'left']}],
+            'jumps': [],
+            'execution_permits': {'T1': True, 'DC1': True},
+            'items_module_name': 'spine_items',
+            'settings': {
+                'engineSettings/remoteExecutionEnabled': 'true',
+                'engineSettings/remoteHost': '192.168.56.69',
+                'engineSettings/remotePort': 50001,
+                'engineSettings/remoteSecurityFolder': '',
+                'engineSettings/remoteSecurityModel': '',
+            },
+            'project_dir': 'C:/Users/ttepsa/OneDrive - Teknologian Tutkimuskeskus VTT/Documents/SpineToolboxProjects/remote test 2 dags',
+        }
         return engine_data
 
     def make_engine_data2(self):
-        engine_data = {'items': {
-            'Importer 1': {'type': 'Importer', 'description': '', 'x': 72.45758726309028, 'y': -80.20321040425301,
-                           'specification': 'Importer 1 - pekka_units.xlsx - 0', 'cancel_on_error': True,
-                           'purge_before_writing': True, 'on_conflict': 'replace',
-                           'file_selection': [['<pekka data>/pekka_units.xlsx', True]]},
-            'DS1': {'type': 'Data Store', 'description': '', 'x': 211.34193262411353, 'y': -152.99750295508272,
-                    'url': {'dialect': 'sqlite', 'username': '', 'password': '', 'host': '', 'port': '',
-                            'database': {'type': 'path', 'relative': True, 'path': '.spinetoolbox/items/ds1/DS1.sqlite'}}},
-            'pekka data': {'type': 'Data Connection', 'description': '', 'x': -78.23453014184398, 'y': -145.98354018912534,
-                           'file_references': [], 'db_references': [], 'db_credentials': {}}}, 'specifications': {
-            'Importer': [{'name': 'Importer 1 - pekka_units.xlsx - 0', 'item_type': 'Importer', 'mapping': {
-                'table_mappings': {'Sheet1': [{'map_type': 'ObjectClass', 'name': {'map_type': 'column', 'reference': 0},
-                                               'parameters': {'map_type': 'None'}, 'skip_columns': [], 'read_start_row': 0,
-                                               'objects': {'map_type': 'column', 'reference': 1}}]}, 'table_options': {},
-                'table_types': {'Sheet1': {'0': 'string', '1': 'string'}}, 'table_row_types': {},
-                'selected_tables': ['Sheet1'], 'source_type': 'ExcelConnector'}, 'description': None,
-                          'definition_file_path': 'C:\\Users\\ttepsa\\OneDrive - Teknologian Tutkimuskeskus VTT\\Documents\\SpineToolboxProjects\\Simple Importer\\Importer 1 - pekka_units.xlsx - 0.json'}]},
-                      'connections': [{'name': 'from pekka data to Importer 1', 'from': ['pekka data', 'right'],
-                                       'to': ['Importer 1', 'left']},
-                                      {'name': 'from Importer 1 to DS1', 'from': ['Importer 1', 'right'],
-                                       'to': ['DS1', 'left']}], 'jumps': [],
-                      'execution_permits': {'Importer 1': True, 'DS1': True, 'pekka data': True},
-                      'items_module_name': 'spine_items',
-                      'settings': {'engineSettings/remoteExecutionEnabled': 'true',
-                                   'engineSettings/remoteHost': '192.168.56.69', 'engineSettings/remotePort': 50001,
-                                   'engineSettings/remoteSecurityFolder': '', 'engineSettings/remoteSecurityModel': ''},
-                      'project_dir': 'C:/Users/ttepsa/OneDrive - Teknologian Tutkimuskeskus VTT/Documents/SpineToolboxProjects/Simple Importer'}
+        engine_data = {
+            'items': {
+                'Importer 1': {
+                    'type': 'Importer',
+                    'description': '',
+                    'x': 72.45758726309028,
+                    'y': -80.20321040425301,
+                    'specification': 'Importer 1 - pekka_units.xlsx - 0',
+                    'cancel_on_error': True,
+                    'purge_before_writing': True,
+                    'on_conflict': 'replace',
+                    'file_selection': [['<pekka data>/pekka_units.xlsx', True]],
+                },
+                'DS1': {
+                    'type': 'Data Store',
+                    'description': '',
+                    'x': 211.34193262411353,
+                    'y': -152.99750295508272,
+                    'url': {
+                        'dialect': 'sqlite',
+                        'username': '',
+                        'password': '',
+                        'host': '',
+                        'port': '',
+                        'database': {'type': 'path', 'relative': True, 'path': '.spinetoolbox/items/ds1/DS1.sqlite'},
+                    },
+                },
+                'pekka data': {
+                    'type': 'Data Connection',
+                    'description': '',
+                    'x': -78.23453014184398,
+                    'y': -145.98354018912534,
+                    'file_references': [],
+                    'db_references': [],
+                    'db_credentials': {},
+                },
+            },
+            'specifications': {
+                'Importer': [
+                    {
+                        'name': 'Importer 1 - pekka_units.xlsx - 0',
+                        'item_type': 'Importer',
+                        'mapping': {
+                            'table_mappings': {
+                                'Sheet1': [
+                                    {
+                                        'map_type': 'ObjectClass',
+                                        'name': {'map_type': 'column', 'reference': 0},
+                                        'parameters': {'map_type': 'None'},
+                                        'skip_columns': [],
+                                        'read_start_row': 0,
+                                        'objects': {'map_type': 'column', 'reference': 1},
+                                    }
+                                ]
+                            },
+                            'table_options': {},
+                            'table_types': {'Sheet1': {'0': 'string', '1': 'string'}},
+                            'table_row_types': {},
+                            'selected_tables': ['Sheet1'],
+                            'source_type': 'ExcelConnector',
+                        },
+                        'description': None,
+                        'definition_file_path': 'C:\\Users\\ttepsa\\OneDrive - Teknologian Tutkimuskeskus VTT\\Documents\\SpineToolboxProjects\\Simple Importer\\Importer 1 - pekka_units.xlsx - 0.json',
+                    }
+                ]
+            },
+            'connections': [
+                {
+                    'name': 'from pekka data to Importer 1',
+                    'from': ['pekka data', 'right'],
+                    'to': ['Importer 1', 'left'],
+                },
+                {'name': 'from Importer 1 to DS1', 'from': ['Importer 1', 'right'], 'to': ['DS1', 'left']},
+            ],
+            'jumps': [],
+            'execution_permits': {'Importer 1': True, 'DS1': True, 'pekka data': True},
+            'items_module_name': 'spine_items',
+            'settings': {
+                'engineSettings/remoteExecutionEnabled': 'true',
+                'engineSettings/remoteHost': '192.168.56.69',
+                'engineSettings/remotePort': 50001,
+                'engineSettings/remoteSecurityFolder': '',
+                'engineSettings/remoteSecurityModel': '',
+            },
+            'project_dir': 'C:/Users/ttepsa/OneDrive - Teknologian Tutkimuskeskus VTT/Documents/SpineToolboxProjects/Simple Importer',
+        }
         return engine_data
 
     def test_make_server_msg_and_parse1(self):

--- a/tests/server/util/test_ZipHandler.py
+++ b/tests/server/util/test_ZipHandler.py
@@ -22,7 +22,6 @@ from spine_engine.server.util.zip_handler import ZipHandler
 
 
 class TestZipHandler(unittest.TestCase):
-
     def test_package(self):
         src = os.path.join(str(Path(__file__).parent), "projectforpackagingtests")
         dst = os.path.join(src, os.pardir)

--- a/tests/utils/test_helpers.py
+++ b/tests/utils/test_helpers.py
@@ -99,11 +99,11 @@ class TestGetFileSize(unittest.TestCase):
         expected_output = "2.0 KB"
         output = get_file_size(s)
         self.assertEqual(expected_output, output)
-        s = 1024*1024*2
+        s = 1024 * 1024 * 2
         expected_output = "2.0 MB"
         output = get_file_size(s)
         self.assertEqual(expected_output, output)
-        s = 1024*1024*1024*2
+        s = 1024 * 1024 * 1024 * 2
         expected_output = "2.0 GB"
         output = get_file_size(s)
         self.assertEqual(expected_output, output)


### PR DESCRIPTION
We need to catch possible exception in `PersistentManagerBase._issue_command()` to not allow the Engine to fail.

Fixes Spine-project/Spine-Toolbox#1849

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
