### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -28,7 +28,7 @@ jobs:
         PYTHONUTF8: 1
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/Spine-project/Spine-Database-API.git#egg=spinedb_api
+        pip install git+https://github.com/Spine-project/Spine-Database-API.git@python310#egg=spinedb_api
         pip install .
         pip install --no-deps git+https://github.com/Spine-project/spine-items.git#egg=spine_items
         pip install coverage
@@ -64,7 +64,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/Spine-project/Spine-Database-API.git#egg=spinedb_api
+        pip install git+https://github.com/Spine-project/Spine-Database-API.git@python310#egg=spinedb_api
         pip install .
         pip install --no-deps git+https://github.com/Spine-project/spine-items.git#egg=spine_items
         pip install coverage

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/run_unit_tests.yml
+++ b/.github/workflows/run_unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install git+https://github.com/Spine-project/Spine-Database-API.git@python310#egg=spinedb_api
         pip install .
-        pip install --no-deps git+https://github.com/Spine-project/spine-items.git#egg=spine_items
+        pip install --no-deps git+https://github.com/Spine-project/spine-items.git@python310#egg=spine_items
         pip install coverage
         pip install codecov
     - name: Display coverage version
@@ -66,7 +66,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install git+https://github.com/Spine-project/Spine-Database-API.git@python310#egg=spinedb_api
         pip install .
-        pip install --no-deps git+https://github.com/Spine-project/spine-items.git#egg=spine_items
+        pip install --no-deps git+https://github.com/Spine-project/spine-items.git@python310#egg=spine_items
         pip install coverage
         pip install codecov
     - name: Display coverage version

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spine Engine
 
-[![Python](https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9-blue.svg)](https://www.python.org/downloads/release/python-379/)
+[![Python](https://img.shields.io/badge/python-3.7%20|%203.8%20|%203.9%20|%203.10-blue.svg)](https://www.python.org/downloads/release/python-379/)
 [![Unit tests](https://github.com/Spine-project/spine-engine/workflows/Unit%20tests/badge.svg)](https://github.com/Spine-project/spine-engine/actions?query=workflow%3A"Unit+tests")
 [![codecov](https://codecov.io/gh/Spine-project/spine-engine/branch/master/graph/badge.svg)](https://codecov.io/gh/Spine-project/spine-engine)
 [![PyPI version](https://badge.fury.io/py/spine-engine.svg)](https://badge.fury.io/py/spine-engine)


### PR DESCRIPTION
Update spine-engine to support Python 3.10

Re https://github.com/Spine-project/Spine-Toolbox/issues/1700

## Checklist before merging
- [x] Documentation (also in Toolbox repo) is up-to-date
- [x] Release notes in Toolbox repo have been updated
- [x] Unit tests have been added/updated accordingly
- [x] Code has been formatted by black
- [x] Unit tests pass
