### PR TITLE
Fix bug in kernel execution

### DIFF
--- a/spine_engine/execution_managers/kernel_execution_manager.py
+++ b/spine_engine/execution_managers/kernel_execution_manager.py
@@ -299,7 +299,7 @@ class KernelExecutionManager(ExecutionManagerBase):
 
     def run_until_complete(self):
         if self._kernel_client is None:
-            return 0
+            return -1
         self._kernel_client.start_channels()
         run_succeeded = self._do_run()
         self._kernel_client.stop_channels()


### PR DESCRIPTION
The bug mistakenly gave a green check mark to a Tool on Design View after execution even when Jupyter Console fails to start. For example, when kernel does not exist.

No related issue.

## Checklist before merging
- [x] Code has been formatted by black & isort
- [x] Unit tests pass
